### PR TITLE
Fix Inputs section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   * region
   * instance_type
   * instance_count
-  * az_letters
+  * az_list
   * network_prefix
   * subnet_ids
   * security_groups


### PR DESCRIPTION
Commit e9a369b changed the input variable name for Availability Zones from `az_letters` to `az_list`.
