### PR TITLE
fix incompatible usage vs terraform v0.7

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "aws_instance" "nat" {
     iam_instance_profile = "${aws_iam_instance_profile.nat_profile.id}"
     key_name = "${var.aws_key_name}"
     subnet_id = "${element(split(\",\", var.subnet_ids), count.index)}"
-    security_groups = ["${split(\",\", var.security_groups)}"]
+    vpc_security_group_ids = ["${split(\",\", var.vpc_security_group_ids)}"]
     tags {
         Name = "NAT ${element(split(\",\", var.az_list), count.index)}${count.index+1}"
     }

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "instance_count" {}
 variable "az_list" {}
 variable "networkprefix" {}
 variable "subnet_ids" {}
-variable "security_groups" {}
+variable "vpc_security_group_ids" {}
 variable "aws_key_name" {}
 variable "aws_key_location" {}
 variable "account" {}


### PR DESCRIPTION
`security_groups` -> `vpc_security_group_ids`

per:  https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#070-august-2-2016
