### PR TITLE
Update terraform syntax to be compatible with 0.9

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_instance_profile" "nat_profile" {
     name = "nat_ha_profile"
-    roles = ["${aws_iam_role.role.name}"]
+    role = "${aws_iam_role.role.name}"
 }
 
 resource "aws_iam_role" "role" {

--- a/main.tf
+++ b/main.tf
@@ -12,19 +12,19 @@ resource "aws_instance" "nat" {
     source_dest_check = false
     iam_instance_profile = "${aws_iam_instance_profile.nat_profile.id}"
     key_name = "${var.aws_key_name}"
-    subnet_id = "${element(split(\",\", var.subnet_ids), count.index)}"
-    vpc_security_group_ids = ["${split(\",\", var.vpc_security_group_ids)}"]
+    subnet_id = "${element(var.subnet_ids, count.index)}"
+    vpc_security_group_ids = ["${var.vpc_security_group_ids}"]
     tags {
-        Name = "NAT ${element(split(\",\", var.az_list), count.index)}${count.index+1}"
+        Name = "NAT ${element(var.az_list, count.index)}${count.index+1}"
     }
-    user_data = "${replace(replace(file(\"${path.module}/nat.conf\"), \"__NETWORKPREFIX__\", \"${var.networkprefix}\"), \"__MYAZ__\", element(split(\",\", var.az_list), count.index))}"
+    user_data = "${replace(replace(file("${path.module}/nat.conf"), "__NETWORKPREFIX__", "${var.networkprefix}"), "__MYAZ__", element(var.az_list, count.index))}"
     provisioner "remote-exec" {
         inline = [
           "while sudo pkill -0 cloud-init; do sleep 2; done"
         ]
         connection {
           user = "ubuntu"
-          key_file = "${var.aws_key_location}"
+          private_key = "${var.aws_key_location}"
         }
     }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "private_ips" {
-  value = "${join(\",\", aws_instance.nat.*.private_ip)}"
+  value = ["${aws_instance.nat.*.private_ip}"]
 }
 output "public_ips" {
-  value = "${join(\",\", aws_instance.nat.*.public_ip)}"
+  value = ["${aws_instance.nat.*.public_ip}"]
 }
 output "instance_ids" {
-  value = "${join(\",\", aws_instance.nat.*.id)}"
+  value = ["${aws_instance.nat.*.id}"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,16 @@
 variable "region" {}
 variable "instance_type" {}
 variable "instance_count" {}
-variable "az_list" {}
+variable "az_list" {
+  type = "list"
+}
 variable "networkprefix" {}
-variable "subnet_ids" {}
-variable "vpc_security_group_ids" {}
+variable "subnet_ids" {
+  type = "list"
+}
+variable "vpc_security_group_ids" {
+  type = "list"
+}
 variable "aws_key_name" {}
 variable "aws_key_location" {}
-variable "account" {}
 


### PR DESCRIPTION
- `roles` is deprecated in aws_iam_instance_profile
- Use lists rather than splitting a string on commas

Changing the variables to lists rather than CSV strings is now possible, but might constitute a breaking change. I can back out that change if you'd rather.

Fixes #3 