### PR TITLE
Replace tf_aws_ubuntu_ami module with built in data.aws_ami

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 ## Inputs
 
-  * region
+  * ami_name_pattern
+  * ami_publisher
   * instance_type
   * instance_count
   * az_list
@@ -15,7 +16,6 @@
   * security_groups
   * aws_key_name
   * aws_key_location
-  * account
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,22 @@
-module "ami" {
-  source = "github.com/terraform-community-modules/tf_aws_ubuntu_ami/ebs"
-  instance_type = "${var.instance_type}"
-  region = "${var.region}"
-  distribution = "vivid"
+data "aws_ami" "ami" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["${var.ami_name_pattern}"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["${var.ami_publisher}"]
 }
 
 resource "aws_instance" "nat" {
     count = "${var.instance_count}"
-    ami = "${module.ami.ami_id}"
+    ami = "${data.aws_ami.ami.id}"
     instance_type = "${var.instance_type}"
     source_dest_check = false
     iam_instance_profile = "${aws_iam_instance_profile.nat_profile.id}"

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,12 @@
-variable "region" {}
+variable "ami_name_pattern" {
+  default = "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"
+  description = "The name filter to use in data.aws_ami"
+}
+variable "ami_publisher" {
+  default = "099720109477" # Canonical
+  description = "The AWS account ID of the AMI publisher"
+}
+
 variable "instance_type" {}
 variable "instance_count" {}
 variable "az_list" {}


### PR DESCRIPTION
Terraform now has an built in (and auto updating) way of searching for AMIs - lets use that instead of the previous (manually updated) module.

I have also updated the base image from 15.04 to 16.04 (because its LTS)