### PR TITLE
Don't install extra packages on the instance.

### DIFF
--- a/nat-user-data.conf.tmpl
+++ b/nat-user-data.conf.tmpl
@@ -1,17 +1,11 @@
 #cloud-config
 # -*- YAML -*-
-apt_sources:
- - source: "deb http://apt.puppetlabs.com vivid main"
-   keyid: 1054b7a24bd6ec30
 apt_upgrade: true
 locale: en_US.UTF-8
 packages:
- - puppet
- - git
  - traceroute
  - nmap
  - keepalived
- - python-pip
 write_files:
 -   path: /lib/systemd/system/awsnycast.service
     content: |


### PR DESCRIPTION
We don't need pupet, git or pip installed for anything this instance does.

(This PR isn't important but these packages seemed out of place - likely from the company where this module was first extracted)