### PR TITLE
Run iptables/sysctl on _every_ boot, not just first

### DIFF
--- a/nat-user-data.conf.tmpl
+++ b/nat-user-data.conf.tmpl
@@ -63,6 +63,11 @@ write_files:
                     instance: SELF
                     healthcheck: public
                     if_unhealthy: true
+# The commands below need to run on every boot, but bootcmd runs too early,
+# before the write_files has run, but on every boot, where as runcmd only runs
+# on the first time this instance is booted.
+bootcmd:
+  - [ sh, -c, "[ -x /var/lib/cloud/instance/scripts/runcmd ] && /var/lib/cloud/instance/scripts/runcmd" ]
 runcmd:
  - [ sh, -c, "echo 1 > /proc/sys/net/ipv4/ip_forward;echo 655361 > /proc/sys/net/netfilter/nf_conntrack_max" ]
  - [ iptables, -N, LOGGINGF ]


### PR DESCRIPTION
The `runcmd` step of cloudinit will only run once per instance (not once per boot), but the iptables rules created here need to run on every single boot (in the case of reboot for any reason.) 

`bootcmd` is ideally the cloudinit module we want to use.

But that runs too early (before write_files has dropped the config files) so we need to use a trick to run the script the runcmd drops from bootcmd. Little bit hacky, but needed if an instance reboots