### PR TITLE
Update awsnycast

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
   * instance_type
   * instance_count
   * az_list
-  * subnet_ids
+  * public_subnet_ids
+  * private_subnet_ids
   * security_groups
   * aws_key_name
   * aws_key_location

--- a/main.tf
+++ b/main.tf
@@ -14,12 +14,15 @@ data "aws_ami" "ami" {
   owners = ["${var.ami_publisher}"]
 }
 
-# We are given as input a list of subnets to create the NAT in. Lets use them to find out about the VPC.
 data "aws_subnet" "first" {
-  id = "${var.subnet_ids[0]}"
+  id = "${var.public_subnet_ids[0]}"
 }
 data "aws_vpc" "vpc" {
   id = "${data.aws_subnet.first.vpc_id}"
+}
+
+data "aws_region" "current" {
+  current = true
 }
 
 data "template_file" "user_data" {
@@ -27,8 +30,11 @@ data "template_file" "user_data" {
   count = "${var.instance_count}"
 
   vars {
-    myaz = "${element(var.az_list, count.index)}"
+    name = "${var.name}"
+    mysubnet = "${element(var.private_subnet_ids, count.index)}"
     vpc_cidr = "${data.aws_vpc.vpc.cidr_block}"
+    region = "${data.aws_region.current.name}"
+    awsnycast_deb_url = "${var.awsnycast_deb_url}"
   }
 }
 
@@ -39,7 +45,7 @@ resource "aws_instance" "nat" {
     source_dest_check = false
     iam_instance_profile = "${aws_iam_instance_profile.nat_profile.id}"
     key_name = "${var.aws_key_name}"
-    subnet_id = "${element(var.subnet_ids, count.index)}"
+    subnet_id = "${element(var.public_subnet_ids, count.index)}"
     vpc_security_group_ids = ["${var.vpc_security_group_ids}"]
     tags = "${merge(var.tags, map("Name", format("%s-nat%d", var.name, count.index+1)))}"
     user_data = "${element(data.template_file.user_data.*.rendered, count.index)}"

--- a/nat-user-data.conf.tmpl
+++ b/nat-user-data.conf.tmpl
@@ -44,6 +44,7 @@ write_files:
                    - cidr: 0.0.0.0/0
                      instance: SELF
                      healthcheck: public
+                     never_delete: true
              other_azs:
                 find:
                     type: and

--- a/nat-user-data.conf.tmpl
+++ b/nat-user-data.conf.tmpl
@@ -29,17 +29,9 @@ write_files:
         routetables:
              my_az:
                 find:
-                    type: and
+                    type: subnet
                     config:
-                        filters:
-                          - type: by_tag
-                            config:
-                                key: az
-                                value: ${myaz}
-                          - type: by_tag
-                            config:
-                                key: type
-                                value: private
+                        subnet_id: ${mysubnet}
                 manage_routes:
                    - cidr: 0.0.0.0/0
                      instance: SELF
@@ -50,15 +42,14 @@ write_files:
                     type: and
                     config:
                         filters:
-                          - type: by_tag
+                          - type: subnet
                             not: true
                             config:
-                                key: az
-                                value: ${myaz}
-                          - type: by_tag
+                                subnet_id: ${mysubnet}
+                          - type: by_tag_regexp
                             config:
-                                key: type
-                                value: private
+                                key: Name
+                                regexp: ${name}-rt-private-${region}[a-z]
                 manage_routes:
                   - cidr: 0.0.0.0/0
                     instance: SELF
@@ -83,5 +74,5 @@ runcmd:
  - [ iptables, -I, INPUT, -i, lo, -j, ACCEPT ]
  - [ iptables, -A, INPUT, -j, LOGGINGI ]
  - [ iptables, -P, INPUT, DROP ]
- - [ sh, -c, "cd /tmp;wget https://github.com/bobtfish/AWSnycast/releases/download/v0.0.9/awsnycast_0.0.9-249_amd64.deb&&dpkg -i awsnycast_0.0.9-249_amd64.deb" ]
+ - [ sh, -c, "which AWSnycast || { cd /tmp && wget ${awsnycast_deb_url} && dpkg -i awsnycast_*.deb && rm *.deb; }" ]
  - [ systemctl, start, awsnycast ]

--- a/variables.tf
+++ b/variables.tf
@@ -18,8 +18,14 @@ variable "instance_count" {}
 variable "az_list" {
   type = "list"
 }
-variable "subnet_ids" {
+variable "public_subnet_ids" {
   type = "list"
+}
+variable "private_subnet_ids" {
+  type = "list"
+}
+variable "subnets_count" {
+  description = "The number of subnets in public_subnet_ids. Required because of hashicorp/terraform#1497"
 }
 variable "vpc_security_group_ids" {
   type = "list"
@@ -27,3 +33,6 @@ variable "vpc_security_group_ids" {
 variable "aws_key_name" {}
 variable "aws_key_location" {}
 
+variable "awsnycast_deb_url" {
+  default = "https://github.com/bobtfish/AWSnycast/releases/download/v0.1.5/awsnycast_0.1.5-425_amd64.deb"
+}


### PR DESCRIPTION
Closes #4.

Update the config for AWSnycast to pick up the Route tables as created by tf_aws_vpc.

To make this work we needed to update the version of AWSnycast. To make it easier for users of this module to update in the future I have made the URL it fetches the .deb from a variable with a default of the current latest release.