### PR TITLE
Allow multiple copies of module to exist in one account

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,10 +1,10 @@
 resource "aws_iam_instance_profile" "nat_profile" {
-    name = "nat_ha_profile"
+    name = "${var.name}-nat_ha_profile"
     role = "${aws_iam_role.role.name}"
 }
 
 resource "aws_iam_role" "role" {
-    name = "nat_ha_role"
+    name = "${var.name}-nat_ha_role"
     path = "/"
     assume_role_policy = <<EOF
 {


### PR DESCRIPTION
Without including the name in the created-role we end up with an error
like this one:

    * aws_iam_role.role: Error creating IAM Role nat_ha_role: EntityAlreadyExists: Role with name nat_ha_role already exists.
            status code: 409, request id: 43a59824-7dc3-11e7-95b1-c9abba16805b