### PR TITLE
Optionall support running the provisioner via an SSH bastion

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,12 @@ resource "aws_instance" "nat" {
         ]
         connection {
           user = "ubuntu"
-          private_key = "${var.aws_key_location}"
+          # If we are using a bastion host ssh in via the private IP
+          # If we set this to an empty string we get the default behaviour.
+          host = "${var.ssh_bastion_host != "" ? self.private_ip : ""}"
+          private_key  = "${var.aws_key_location}"
+          bastion_host = "${var.ssh_bastion_host}"
+          bastion_user = "${var.ssh_bastion_user}"
         }
     }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,12 @@ variable "vpc_security_group_ids" {
 }
 variable "aws_key_name" {}
 variable "aws_key_location" {}
+variable "ssh_bastion_host" {
+  default = ""
+}
+variable "ssh_bastion_user" {
+  default = ""
+}
 
 variable "awsnycast_deb_url" {
   default = "https://github.com/bobtfish/AWSnycast/releases/download/v0.1.5/awsnycast_0.1.5-425_amd64.deb"


### PR DESCRIPTION
This is need for environments such as mine where the SSH is only allowed to a single bastion host.

If a bastion is provided then we use the private_ip to SSH too, not the public