### PR TITLE
Support for new variable route_table_regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 ## Module to launch NAT instances on AWS.
 
-## Example Use
-
 ## Inputs
 
   * ami_name_pattern
@@ -23,6 +21,78 @@
   * private_ips
   * public_ips
   * instance_ids
+
+## Usage
+```hcl
+resource "aws_security_group" "nat" {
+  name = "nat"
+  description = "Allow nat traffic"
+  vpc_id = "${module.vpc.vpc_id}"
+
+  ingress {
+      from_port = 80
+      to_port = 80
+      protocol = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+      from_port = 443
+      to_port = 443
+      protocol = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+      from_port = 49152
+      to_port = 65535
+      protocol = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+      from_port = 80
+      to_port = 80
+      protocol = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+      from_port = 443
+      to_port = 443
+      protocol = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+      from_port = 49152
+      to_port = 65535
+      protocol = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  lifecycle = {
+    create_before_destroy = true
+  }
+}
+
+module "nat" {
+  source                 = "github.com/terraform-community-modules/tf_aws_nat"
+  name                   = "${var.name}"
+  instance_type          = "t2.nano"
+  instance_count         = "2"
+  aws_key_name           = "mykeyname"
+  public_subnet_ids      = "${module.vpc.public_subnets}"
+  private_subnet_ids     = "${module.vpc.private_subnets}"
+  vpc_security_group_ids = ["${aws_security_group.nat.id}"]
+  az_list                = "${var.azs}"
+  subnets_count          = "${length(var.azs)}"
+  route_table_regexp     = "$${name}-private-$${region}[a-z]"
+  ssh_bastion_user       = "ubuntu"
+  ssh_bastion_host       = "${aws_instance.bastion.public_ip}"
+  aws_key_location       = "${file("pathtokeyfile")}"
+}
+```
 
 # LICENSE
 

--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,7 @@ data "template_file" "user_data" {
     vpc_cidr = "${data.aws_vpc.vpc.cidr_block}"
     region = "${data.aws_region.current.name}"
     awsnycast_deb_url = "${var.awsnycast_deb_url}"
+    route_table_regexp = "${var.route_table_regexp}"
   }
 }
 

--- a/nat-user-data.conf.tmpl
+++ b/nat-user-data.conf.tmpl
@@ -49,7 +49,7 @@ write_files:
                           - type: by_tag_regexp
                             config:
                                 key: Name
-                                regexp: ${name}-rt-private-${region}[a-z]
+                                regexp: ${route_table_regexp}
                 manage_routes:
                   - cidr: 0.0.0.0/0
                     instance: SELF

--- a/variables.tf
+++ b/variables.tf
@@ -42,3 +42,8 @@ variable "ssh_bastion_user" {
 variable "awsnycast_deb_url" {
   default = "https://github.com/bobtfish/AWSnycast/releases/download/v0.1.5/awsnycast_0.1.5-425_amd64.deb"
 }
+
+variable "route_table_regexp" {
+  description = "Route table regexp used by AWSnycast"
+  default = "$${name}-rt-private-$${region}[a-z]"
+}


### PR DESCRIPTION
Hello,

The vpc community module drops the resource type in the resource name causing the route table regex to fail.

See:

https://github.com/terraform-community-modules/tf_aws_vpc/blob/master/main.tf#L49

vs

https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/master/main.tf#L83

This PR allows override of the route table regexp used by AWSnycast through a terraform variable. I also added some partial sample usage.

Best,
  Derrick